### PR TITLE
Pass through CORS request headers

### DIFF
--- a/replay-proxy-nginx.conf
+++ b/replay-proxy-nginx.conf
@@ -12,6 +12,7 @@ server {
     location / {
         proxy_pass          http://rpz-container;
         proxy_redirect      off;
+        proxy_pass_request_headers on;
         proxy_set_header    Host  $host;
         proxy_set_header    X-Real-IP $remote_addr;
         proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -26,11 +27,11 @@ server {
         proxy_redirect      off;
         rewrite             ^(.*)$   "://$http_host$1";
         rewrite             ^(.*)$   "http$1" break;
+        proxy_pass_request_headers on;
         proxy_set_header    Host  $host;
         proxy_set_header    X-Real-IP $remote_addr;
-        proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for
-        ;
-    }          
+        proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
 }
 
 


### PR DESCRIPTION
It is common for `Access-Control` response headers to only be set if `Origin` is set in request headers. For the CORS mechanism to work, that `Origin` header has to be passed through.

It would be good to find a server that is configured this way, `https://interactive.guim.co.uk/` seems to now set `Access-Control` headers anyway.